### PR TITLE
attempt to fix demo links to geopackage-viewer-js

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <meta name="author" content="NGA, Daniel Barela">
   <meta name="twitter:site" content="@nga_geoint">
   <meta property="og:site_name" content="NGA">
-  <meta name="twitter:url" content="https://ngageoint.github.io/geopackage-js/">
-  <meta property="og:url" content="https://ngageoint.github.io/geopackage-js/">
+  <meta name="twitter:url" content="https://ngageoint.github.io/geopackage-viewer-js/">
+  <meta property="og:url" content="https://ngageoint.github.io/geopackage-viewer-js/">
   <meta name="twitter:title" content="GeoPackage Viewer">
   <meta property="og:title" content="GeoPackage Viewer">
   <meta name="twitter:description" content="Online GeoPackage viewer. This viewer is able to open GeoPackage files and convert certain types of files to GeoPackages. Powered by a JavaScript library providing GeoPackage functionality and utilities to node and web applications.">
@@ -45,7 +45,7 @@
         You can load a GeoPackage directly from a URL by including a gpkg parameter in the URL.  Specify which layers (if any) you would like to load with layers parameters.
       </div>
       <div style="padding: 7px; font-size: 14px;">
-        For Example <a target="_blank" href="https://ngageoint.github.io/geopackage-js/?gpkg=https://ngageoint.github.io/GeoPackage/examples/rivers.gpkg&layers=rivers">https://ngageoint.github.io/geopackage-js/?gpkg=http://ngageoint.github.io/GeoPackage/examples/rivers.gpkg&layers=rivers</a>
+        For Example <a target="_blank" href="https://ngageoint.github.io/geopackage-viewer-js/?gpkg=https://ngageoint.github.io/GeoPackage/examples/rivers.gpkg&layers=rivers">https://ngageoint.github.io/geopackage-viewer-js/?gpkg=http://ngageoint.github.io/GeoPackage/examples/rivers.gpkg&layers=rivers</a>
       </div>
 
       <div style="font-size: 12px; display: none;" id="loadFromUrl">


### PR DESCRIPTION
links on demo site currently point to:

 https://ngageoint.github.io/geopackage-js/ 

this fix is intended to make them point to:

 https://ngageoint.github.io/geopackage-viewer-js/ 
